### PR TITLE
feat: write to package.json

### DIFF
--- a/src/helpers/commands.ts
+++ b/src/helpers/commands.ts
@@ -13,14 +13,19 @@ export const prettier: ICommand = {
     name: 'proceed',
     message: 'Install Prettier? (Standardize code format: tabs, spaces, semi-colons, e.t.c)',
     commands: [{ command: 'npm', args: ['install', 'prettier', '-D'] }],
-    writeToFile: [{fileName: '.prettierrc.json', content: `{
+    writeToFile: [
+        {
+            fileName: '.prettierrc.json',
+            content: `{
         "trailingComma": "all",
         "tabWidth": 4,
         "semi": false,
         "singleQuote": true,
         "printWidth": 130
     }
-    `} ],
+    `,
+        },
+    ],
     successMessage: 'Installed Prettier and updated package.json.',
 }
 
@@ -39,7 +44,9 @@ export const commitlint: ICommand = {
     name: 'proceed',
     message: 'Install Commitlint? (Lint your commit messages)',
     commands: [{ command: 'npm', args: ['install', '@commitlint/cli', '@commitlint/config-conventional', '-D'] }],
-    writeToFile: [{fileName: 'commitlint.config.js', content: `module.exports = {extends: ['@commitlint/config-conventional']}`}],
+    writeToFile: [
+        { fileName: 'commitlint.config.js', content: `module.exports = {extends: ['@commitlint/config-conventional']}` },
+    ],
     successMessage: 'Installed Commitlint and updated package.json.',
 }
 
@@ -61,6 +68,16 @@ export const husky: ICommand = {
         { command: 'npx', args: ['husky', 'set', '.husky/pre-commit', '"npx pretty-quick --staged"'] },
     ],
     successMessage: 'Installed Husky, added pre-commit hooks and updated package.json.',
+    packageJsonEntries: [
+        {
+            key: 'husky',
+            item: {
+                hooks: {
+                    'prepare-commit-msg': 'exec < /dev/tty && git cz --hook || true',
+                },
+            },
+        },
+    ],
 }
 
 /* Commitizen
@@ -70,6 +87,20 @@ export const commitizen: ICommand = {
     name: 'proceed',
     message: 'Add Commitizen? (A Commandline utility for easily making commits)',
     commands: [{ command: 'npm', args: ['install', 'commitizen', '-D'] }],
+    packageJsonEntries: [
+        {
+            key: 'config',
+            item: {
+                commitizen: {
+                    path: './node_modules/cz-conventional-changelog',
+                },
+            },
+        },
+        {
+            key: 'scripts',
+            item: { commit: 'cz' },
+        },
+    ],
 }
 
 /* Semantic Release - Best for NPM Packages
@@ -85,6 +116,12 @@ export const semanticRelease: ICommand = {
         { command: 'npm', args: ['install', '@semantic-release/git', '-D'] },
     ],
     successMessage: 'Configured Semantic Release and updated package.json.',
+    packageJsonEntries: [
+        {
+            key: 'scripts',
+            item: { 'semantic-release': 'semantic-release' },
+        },
+    ],
 }
 
 /* Standard Version - Best for non npm projects
@@ -95,6 +132,12 @@ export const standardVersion: ICommand = {
     message: 'Configure Standard Version? (To Automate Versioning and Changelog Generation)',
     commands: [{ command: 'npm', args: ['install', 'standard-version', '-D'] }],
     successMessage: 'Installed Standard Version and updated package.json.',
+    packageJsonEntries: [
+        {
+            key: 'scripts',
+            item: { release: 'standard-release' },
+        },
+    ],
 }
 
 export const readMe: ICommand = {

--- a/src/helpers/commands.ts
+++ b/src/helpers/commands.ts
@@ -86,16 +86,10 @@ export const commitizen: ICommand = {
     type: 'confirm',
     name: 'proceed',
     message: 'Add Commitizen? (A Commandline utility for easily making commits)',
-    commands: [{ command: 'npm', args: ['install', 'commitizen', '-D'] }],
+    commands: [{ command: 'npm', args: ['install', 'commitizen', '-D'] }, {
+        command: 'npx', args: ['init', 'cz-conventional-changelog','-D','--save-exact']
+    }],
     packageJsonEntries: [
-        {
-            key: 'config',
-            item: {
-                commitizen: {
-                    path: './node_modules/cz-conventional-changelog',
-                },
-            },
-        },
         {
             key: 'scripts',
             item: { commit: 'cz' },

--- a/src/helpers/write-to-package.json.ts
+++ b/src/helpers/write-to-package.json.ts
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+
+/**
+ * Adds a script or value to the package.json file
+ * If the key doesn't exist, it will be created.
+ * 
+ * @param key {string} - the key in the package.json file
+ * @param value the value to set the key to
+ */
+export function editToPackageJson(key: string, item: {key: string, value: string}) {
+    const file = fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+    const line = file.split(/\r\n|\n/)[1]
+
+    // Determine tabWidth
+    let tabWidth = 4
+    if(!/    /gm.test(line) && /  /gm.test(line)) tabWidth = 2
+
+    const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'))
+    if(!packageJson[key]) packageJson[key] = {}
+    packageJson[key][item.key] = item.value
+    fs.writeFileSync(path.join(process.cwd(), 'package.json'), JSON.stringify(packageJson, null, tabWidth), 'utf8')
+}
+

--- a/src/interfaces/command.ts
+++ b/src/interfaces/command.ts
@@ -7,6 +7,7 @@ export type ICommand = {
     commands?: CLICommand[],
     writeToFile?: {fileName: string, content:string}[], 
     successMessage?: string,
+    packageJsonEntries?: {key: string, item: {[index: string]: string | Object}}[],
 } & QuestionCollection
 
 export type CLICommand = {


### PR DESCRIPTION
# Write to `package.json`

- Adds the husky configuration for [commitizen](https://github.com/commitizen/cz-cli#husky):
  ```
  "husky": {
    "hooks": {
      "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
    }
  }
  ```
- Updates the repository to use the [`cz-conventional-changelog` adapter](https://github.com/commitizen/cz-cli#making-your-repo-commitizen-friendly)